### PR TITLE
fix: Serenaツール名プレフィックスを削除し、ツール取得にリトライロジックを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,5 @@ vite.config.ts.timestamp-*
 
 # Claude Code
 .claude/settings.local.json
-.mcp.jsontest-serena-tools.ts
+.mcp.json
+test-serena-tools.ts

--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ vite.config.ts.timestamp-*
 
 # Claude Code
 .claude/settings.local.json
-.mcp.json
+.mcp.jsontest-serena-tools.ts

--- a/config-schema.json
+++ b/config-schema.json
@@ -1,72 +1,94 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/shin902/serena-modular-mcp/refs/heads/main/config-schema.json",
-  "title": "Serena Modular MCP Configuration",
-  "description": "Configuration schema for Serena Modular MCP server and categories",
   "type": "object",
   "properties": {
-    "$schema": {
-      "type": "string",
-      "description": "JSON Schema reference"
-    },
     "mcpServers": {
       "type": "object",
-      "description": "MCP server configurations",
       "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Description of the MCP server"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["stdio", "sse"],
-            "description": "Server connection type"
-          },
-          "command": {
-            "type": "string",
-            "description": "Command to execute the server"
-          },
-          "args": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Command arguments"
-          },
-          "env": {
+        "anyOf": [
+          {
             "type": "object",
-            "additionalProperties": {
-              "type": "string"
+            "properties": {
+              "type": {
+                "const": "stdio",
+                "default": "stdio"
+              },
+              "description": {
+                "type": "string"
+              },
+              "command": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "env": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
             },
-            "description": "Environment variables"
+            "required": ["description", "command"]
           },
-          "_comment": {
-            "type": "string",
-            "description": "Optional comment field"
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "description": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["type", "description", "url"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "sse"
+              },
+              "description": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["type", "description", "url"]
           }
-        },
-        "required": ["type", "command"]
+        ]
       }
-    },
-    "_categoriesComment": {
-      "type": "string",
-      "description": "Optional comment about categories"
     },
     "categories": {
       "type": "object",
-      "description": "Tool categories with server assignments",
       "additionalProperties": {
         "type": "object",
         "properties": {
           "description": {
-            "type": "string",
-            "description": "Category description"
+            "type": "string"
           },
           "server": {
-            "type": "string",
-            "description": "Server name this category belongs to"
+            "type": "string"
           },
           "tools": {
             "type": "object",
@@ -75,30 +97,29 @@
                 "type": "array",
                 "items": {
                   "type": "string"
-                },
-                "description": "List of tool names to include in this category"
+                }
               },
               "overrides": {
                 "type": "object",
-                "description": "Tool-specific configuration overrides",
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
                     "enabled": {
                       "type": "boolean",
-                      "description": "Whether the tool is enabled"
+                      "default": true
                     },
                     "description": {
-                      "type": "string",
-                      "description": "Override description for the tool"
+                      "type": "string"
                     }
-                  }
+                  },
+                  "required": []
                 }
               }
-            }
+            },
+            "required": ["includeNames"]
           }
         },
-        "required": ["description", "server"]
+        "required": ["description", "server", "tools"]
       }
     }
   },

--- a/serena-config.json
+++ b/serena-config.json
@@ -23,19 +23,19 @@
       "server": "serena",
       "tools": {
         "includeNames": [
-          "mcp__serena__read_file",
-          "mcp__serena__create_text_file",
-          "mcp__serena__list_dir",
-          "mcp__serena__find_file",
-          "mcp__serena__replace_regex",
-          "mcp__serena__search_for_pattern"
+          "read_file",
+          "create_text_file",
+          "list_dir",
+          "find_file",
+          "replace_regex",
+          "search_for_pattern"
         ],
         "overrides": {
-          "mcp__serena__read_file": {
+          "read_file": {
             "enabled": true,
             "description": "大きなファイルは範囲指定を推奨（O(n) 回避）。"
           },
-          "mcp__serena__replace_regex": {
+          "replace_regex": {
             "enabled": true,
             "description": "正規表現の安全性に注意（バックトラッキング過多を避ける）。"
           }
@@ -47,16 +47,16 @@
       "server": "serena",
       "tools": {
         "includeNames": [
-          "mcp__serena__get_symbols_overview",
-          "mcp__serena__find_symbol",
-          "mcp__serena__find_referencing_symbols",
-          "mcp__serena__replace_symbol_body",
-          "mcp__serena__insert_after_symbol",
-          "mcp__serena__insert_before_symbol",
-          "mcp__serena__rename_symbol"
+          "get_symbols_overview",
+          "find_symbol",
+          "find_referencing_symbols",
+          "replace_symbol_body",
+          "insert_after_symbol",
+          "insert_before_symbol",
+          "rename_symbol"
         ],
         "overrides": {
-          "mcp__serena__replace_symbol_body": {
+          "replace_symbol_body": {
             "enabled": false
           }
         }
@@ -67,10 +67,10 @@
       "server": "serena",
       "tools": {
         "includeNames": [
-          "mcp__serena__write_memory",
-          "mcp__serena__read_memory",
-          "mcp__serena__list_memories",
-          "mcp__serena__delete_memory"
+          "write_memory",
+          "read_memory",
+          "list_memories",
+          "delete_memory"
         ]
       }
     },
@@ -79,15 +79,15 @@
       "server": "serena",
       "tools": {
         "includeNames": [
-          "mcp__serena__activate_project",
-          "mcp__serena__switch_modes",
-          "mcp__serena__get_current_config",
-          "mcp__serena__onboarding",
-          "mcp__serena__check_onboarding_performed",
-          "mcp__serena__prepare_for_new_conversation"
+          "activate_project",
+          "switch_modes",
+          "get_current_config",
+          "onboarding",
+          "check_onboarding_performed",
+          "prepare_for_new_conversation"
         ],
         "overrides": {
-          "mcp__serena__execute_shell_command": {
+          "execute_shell_command": {
             "enabled": false
           }
         }
@@ -98,10 +98,10 @@
       "server": "serena",
       "tools": {
         "includeNames": [
-          "mcp__serena__think_about_collected_information",
-          "mcp__serena__think_about_task_adherence",
-          "mcp__serena__think_about_whether_you_are_done",
-          "mcp__serena__initial_instructions"
+          "think_about_collected_information",
+          "think_about_task_adherence",
+          "think_about_whether_you_are_done",
+          "initial_instructions"
         ]
       }
     }


### PR DESCRIPTION
## 概要

Serenaサーバーから返されるツール名が実際には`mcp__serena__`というプレフィックスを持たないことが原因で、fsカテゴリを含むすべてのツールが取得されていない問題を修正しました。

## 主な変更点

### 🔧 Serenaツール名の修正

**以前**: `mcp__serena__read_file`、`mcp__serena__create_text_file`など

**現在**: `read_file`、`create_text_file`など

- serena-config.jsonのすべてのカテゴリ（fs、code、memory、session、meta）でツール名から`mcp__serena__`プレフィックスを削除

### 🎯 ツール取得の信頼性向上

1. **リトライロジック実装**（client-manager.ts:76-124）
   - `listToolsWithRetry`メソッドを追加
   - 最大30回、2秒間隔でリトライ
   - Serenaサーバーの完全起動を待つ仕組みを構築

2. **デバッグログの追加**（client-manager.ts:369-375）
   - 実際に取得されたツール名をログに出力
   - 期待するツール名との比較情報をログに出力
   - トラブルシューティングが容易に

### 📝 ドキュメント・スキーマの改善

config-schema.json を自動生成スクリプトで再生成し、最新の構造を反映

## テスト方法

1. serena-modularサーバーの再起動
2. `get-category-tools`で各カテゴリのツール取得確認
3. 実際に以下を実行してツール取得状況を確認:
   ```
   mcp__serena-modular__get-category-tools with category=fs
   mcp__serena-modular__get-category-tools with category=code
   mcp__serena-modular__get-category-tools with category=memory
   mcp__serena-modular__get-category-tools with category=session
   mcp__serena-modular__get-category-tools with category=meta
   ```

## 技術的な改善点

- **可観測性**: Serena接続時のツール取得プロセスをログで可視化
- **堅牢性**: リトライロジックにより、タイミング依存の問題を解決
- **保守性**: 実際のツール名を使用することで、設定との乖離がなくなる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>