### PR TITLE
refactor: リトライロジックを指数バックオフに改善

### DIFF
--- a/src/client-manager.ts
+++ b/src/client-manager.ts
@@ -77,8 +77,8 @@ export class ClientManager {
 
   /**
    * List tools with retry logic to wait for upstream server to be ready
-   * Uses exponential backoff: 500ms, 1s, 2s, 4s, 8s with a maximum of 5 retries
-   * Total maximum wait time: ~15.5 seconds
+   * Uses exponential backoff with inter-attempt delays: 500ms, 1s, 2s, 4s (maximum 5 retries)
+   * Total maximum wait time: ~7.5 seconds
    * @param client - The MCP client
    * @param groupName - The group name for logging
    * @returns The list of tools from the upstream server
@@ -117,7 +117,7 @@ export class ClientManager {
       }
 
       if (attempt < maxRetries) {
-        // Exponential backoff: 500ms, 1s, 2s, 4s, 8s
+        // Exponential backoff inter-attempt delays: 500ms, 1s, 2s, 4s
         const waitMs = baseDelayMs * 2 ** (attempt - 1);
         await new Promise((resolve) => setTimeout(resolve, waitMs));
       }

--- a/src/client-manager.ts
+++ b/src/client-manager.ts
@@ -99,11 +99,10 @@ export class ClientManager {
           );
           return tools;
         }
-        // Tools list is empty, treat as success but log warning
+        // Tools list is empty, server might still be initializing
         logger.warn(
-          `No tools available from "${groupName}" on attempt ${attempt}`,
+          `No tools available from "${groupName}" on attempt ${attempt}, retrying...`,
         );
-        return tools;
       } catch (error) {
         lastError =
           error instanceof Error


### PR DESCRIPTION
# 概要
アップストリーム MCP サーバーの初期化待機ロジックを改善しました。固定間隔の過度なリトライから、より効率的な指数バックオフ（Exponential Backoff）に変更しています。

---

## 🔧 主な変更点

### リトライロジックの改善
- 以前
  - リトライ回数：30回
  - 待機時間：固定 2秒（合計 60秒）
  - メソッドシグネチャに `maxRetries` と `delayMs` パラメータを含む
- 現在
  - リトライ回数：最大 5回
  - 待機時間：指数バックオフ（500ms、1s、2s、4s）
  - 試行間の総待機時間：最大 7.5秒
  - メソッドシグネチャを簡略化（内部で設定を管理）

### 🎯 実装の改善
- 待機時間の最適化
  - 指数バックオフにより、初期段階での応答性が向上
  - 最大待機時間が 60秒 から 7.5秒 に短縮
  - サーバー準備済みなら接続が高速（1秒未満）に完了する可能性が高い
- コード簡潔化
  - メソッドシグネチャからハードコード値（30, 2000）を削除
  - デフォルト値をメソッド内に内包し、呼び出し側をシンプル化
  - 保守性向上（将来的な設定変更が容易）
- エッジケース処理
  - 空のツールリストを返すサーバーに対する処理を改善
  - エラーが発生していない場合は、空の配列を成功として返却
  - リトライロジックを不必要に中断せず、適切に完了まで実行
- ログ改善
  - 各リトライ試行ごとに詳細ログを出力
  - 空のツールリストに対する警告メッセージを明確化
  - デバッグや問題特定が容易に

---

## 期待効果
- 初期接続の平均遅延が大幅に低減
- 無駄な待機時間が削減されサーバー起動待ちが効率化
- 呼び出しコードの負担が軽減され、可読性／保守性が向上
